### PR TITLE
Additions to options

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,20 @@ naja.makeRequest(method, url, data = null, options = {})
 - `method: string` is the request method, usually `GET` or `POST`. It is case-insensitive.
 - `url: string` is the target URL.
 - `data: ?mixed` can be pretty much anything: array, object, string, `ArrayBuffer`, `Blob`, `FormData`, &hellip;
-- `options: ?Object` can be used to alter the behavior of some extensions (see below). On top of that, it carries the options for the underlying AJAX library, [`qwest`](https://github.com/pyrsmk/qwest). Please refer to its docs for reference.
+- `options: ?Object` can be used to alter the behavior of some components or extensions (see below). On top of that, it carries the options for the underlying AJAX library, [`qwest`](https://github.com/pyrsmk/qwest). Please refer to its docs for reference.
 
 The `makeRequest` method returns a Promise which either resolves to the `response` object containing the parsed response body, or is rejected with the thrown `error`.
+
+#### Default options
+
+You can also provide default options for your extensions or Naja's core components:
+
+```js
+naja.defaultOptions = {
+	history: false,
+	myCustomOption: 42
+};
+```
 
 
 ### Core components

--- a/README.md
+++ b/README.md
@@ -215,15 +215,18 @@ The true power of Naja is in how easy you can implement your own extensions to i
     - `xhr: XMLHttpRequest`, the aborted XHR object.
 - **success:** This event is dispatched when the request successfully finishes. It has the following properties:
     - `xhr: XMLHttpRequest`, the XHR object,
-    - `response: Object`, the parsed response payload.
+    - `response: Object`, the parsed response payload,
+    - `options: Object`.
 - **error:** This event is dispatched when the request finishes with errors. It has the following properties:
     - `error: Error`, an object describing the error,
     - `xhr: XMLHttpRequest`, the XHR object,
-    - `response: ?Object`, if provided.
+    - `response: ?Object`, if provided,
+    - `options: Object`.
 - **complete:** This event is dispatched when the request finishes, regardless of whether it succeeded or failed. It has the following properties:
     - `error: ?Error`, an object describing the error, if one occurred,
     - `xhr: XMLHttpRequest`, the XHR object,
-    - `response: ?Object`, if provided.
+    - `response: ?Object`, if provided,
+    - `options: Object`.
 
 
 #### Extension implementation

--- a/src/Naja.js
+++ b/src/Naja.js
@@ -84,21 +84,21 @@ export default class Naja extends EventTarget {
 			// qwest does not handle response at all if the request is aborted
 			xhr.addEventListener('abort', () => {
 				this.fireEvent('abort', {xhr});
-				this.fireEvent('complete', {error: new Error('Request aborted'), xhr, response: null});
+				this.fireEvent('complete', {error: new Error('Request aborted'), xhr, response: null, options});
 			});
 		};
 
 		const request = qwest.map(method, url, data, options, beforeCallback)
 			.then((xhr, response) => {
-				this.fireEvent('success', {xhr, response});
-				this.fireEvent('complete', {error: null, xhr, response});
+				this.fireEvent('success', {xhr, response, options});
+				this.fireEvent('complete', {error: null, xhr, response, options});
 				this.load();
 
 				return response;
 			})
 			.catch((error, xhr, response) => {
-				this.fireEvent('error', {error, xhr, response});
-				this.fireEvent('complete', {error, xhr, response});
+				this.fireEvent('error', {error, xhr, response, options});
+				this.fireEvent('complete', {error, xhr, response, options});
 				this.load();
 
 				throw error;

--- a/src/Naja.js
+++ b/src/Naja.js
@@ -21,6 +21,8 @@ export default class Naja extends EventTarget {
 	scriptLoader = null;
 	extensions = [];
 
+	defaultOptions = {};
+
 
 	constructor(uiHandler, redirectHandler, snippetHandler, formsHandler, historyHandler, scriptLoader) {
 		super();
@@ -68,7 +70,7 @@ export default class Naja extends EventTarget {
 			responseType: 'auto',
 		};
 
-		options = objectAssign({}, defaultOptions, options || {});
+		options = objectAssign({}, defaultOptions, this.defaultOptions, options || {});
 
 		let currentXhr;
 		const beforeCallback = (xhr) => {

--- a/src/core/HistoryHandler.js
+++ b/src/core/HistoryHandler.js
@@ -1,5 +1,4 @@
 export default class HistoryHandler {
-	mode = true;
 	popped = false;
 	href = null;
 	initialUrl = null;
@@ -10,7 +9,6 @@ export default class HistoryHandler {
 
 		naja.addEventListener('init', this.initialize.bind(this));
 		naja.addEventListener('interaction', this.configureMode.bind(this));
-		naja.addEventListener('before', this.configureMode.bind(this));
 		naja.addEventListener('before', this.saveUrl.bind(this));
 		naja.addEventListener('success', this.pushNewState.bind(this));
 
@@ -54,14 +52,8 @@ export default class HistoryHandler {
 	}
 
 	configureMode({element, options}) {
-		if (element) {
-			this.mode = this.constructor.normalizeMode(element.getAttribute('data-naja-history'));
-		} else {
-			this.mode = this.constructor.normalizeMode(options.history);
-		}
-
-		// propagate to options if called in interaction event
-		options.history = this.mode;
+		// propagate mode to options
+		options.history = this.constructor.normalizeMode(element.getAttribute('data-naja-history'));
 	}
 
 	static normalizeMode(mode) {
@@ -75,8 +67,9 @@ export default class HistoryHandler {
 		return true;
 	}
 
-	pushNewState({response}) {
-		if (this.mode === false) {
+	pushNewState({response, options}) {
+		const mode = this.constructor.normalizeMode(options.history);
+		if (mode === false) {
 			return;
 		}
 
@@ -84,7 +77,7 @@ export default class HistoryHandler {
 			this.href = response.url;
 		}
 
-		const method = response.replaceHistory || this.mode === 'replace' ? 'replaceState' : 'pushState';
+		const method = response.replaceHistory || mode === 'replace' ? 'replaceState' : 'pushState';
 		this.historyAdapter[method]({
 			href: this.href,
 			title: window.document.title,

--- a/src/core/RedirectHandler.js
+++ b/src/core/RedirectHandler.js
@@ -3,9 +3,9 @@ export default class RedirectHandler {
 		this.naja = naja;
 
 		naja.addEventListener('success', (evt) => {
-			const {response} = evt;
+			const {response, options} = evt;
 			if (response.redirect) {
-				this.makeRedirect(response.redirect, response.forceRedirect);
+				this.makeRedirect(response.redirect, response.forceRedirect || options.forceRedirect);
 				evt.stopImmediatePropagation();
 			}
 		});

--- a/tests/Naja.HistoryHandler.js
+++ b/tests/Naja.HistoryHandler.js
@@ -25,7 +25,7 @@ describe('HistoryHandler', function () {
 
 		mock.expects('addEventListener')
 			.withExactArgs('before', sinon.match.instanceOf(Function))
-			.twice();
+			.once();
 
 		mock.expects('addEventListener')
 			.withExactArgs('success', sinon.match.instanceOf(Function))

--- a/tests/Naja.RedirectHandler.js
+++ b/tests/Naja.RedirectHandler.js
@@ -37,6 +37,23 @@ describe('RedirectHandler', function () {
 		this.requests.pop().respond(200, {'Content-Type': 'application/json'}, JSON.stringify({redirect: '/RedirectHandler/redirect/redirectTo', forceRedirect: true}));
 	});
 
+	it('reads forceRedirect from options', function (done) {
+		const naja = mockNaja();
+		const redirectHandler = new RedirectHandler(naja);
+
+		const mock = sinon.mock(redirectHandler);
+		mock.expects('makeRedirect')
+			.withExactArgs('/RedirectHandler/redirect/redirectTo', true)
+			.once();
+
+		naja.makeRequest('GET', '/RedirectHandler/forceRedirect/options', null, {forceRedirect: true}).then(() => {
+			mock.verify();
+			done();
+		});
+
+		this.requests.pop().respond(200, {'Content-Type': 'application/json'}, JSON.stringify({redirect: '/RedirectHandler/redirect/redirectTo', forceRedirect: false}));
+	});
+
 	it('stops event propagation', function (done) {
 		const naja = mockNaja();
 		const redirectHandler = new RedirectHandler(naja);

--- a/tests/Naja.makeRequest.js
+++ b/tests/Naja.makeRequest.js
@@ -218,4 +218,96 @@ describe('makeRequest()', function () {
 		assert.isTrue(thrown);
 		assert.isFalse(completeCallback.called);
 	});
+
+	describe('options', function () {
+		it('should be set to default options', function (done) {
+			const naja = mockNaja();
+			naja.initialize();
+			cleanPopstateListener(naja.historyHandler);
+
+			const beforeCallback = sinon.spy();
+			naja.addEventListener('before', beforeCallback);
+
+			const request = naja.makeRequest('GET', '/makeRequest/options/defaultOptions');
+			assert.equal(1, this.requests.length);
+
+			request.then(() => {
+				assert.isTrue(beforeCallback.called);
+				assert.isTrue(beforeCallback.calledWith(sinon.match.object
+					.and(sinon.match.has('options', sinon.match.object
+						.and(sinon.match.has('dataType', 'post'))
+						.and(sinon.match.has('responseType', 'auto'))
+					))
+				));
+
+				done();
+			});
+
+			this.requests.pop().respond(200, {'Content-Type': 'application/json'}, JSON.stringify({answer: 42}));
+		});
+
+		it('should be overridden by defaultOptions', function (done) {
+			const naja = mockNaja();
+			naja.initialize();
+			cleanPopstateListener(naja.historyHandler);
+
+			const beforeCallback = sinon.spy();
+			naja.addEventListener('before', beforeCallback);
+
+			naja.defaultOptions = {
+				'dataType': 'json',
+				'customOption': 42,
+			};
+
+			const request = naja.makeRequest('GET', '/makeRequest/options/defaultOptions');
+			assert.equal(1, this.requests.length);
+
+			request.then(() => {
+				assert.isTrue(beforeCallback.called);
+				assert.isTrue(beforeCallback.calledWith(sinon.match.object
+					.and(sinon.match.has('options', sinon.match.object
+						.and(sinon.match.has('dataType', 'json'))
+						.and(sinon.match.has('responseType', 'auto'))
+						.and(sinon.match.has('customOption', 42))
+					))
+				));
+
+				done();
+			});
+
+			this.requests.pop().respond(200, {'Content-Type': 'application/json'}, JSON.stringify({answer: 42}));
+		});
+
+		it('should be overridden by ad-hoc options', function (done) {
+			const naja = mockNaja();
+			naja.initialize();
+			cleanPopstateListener(naja.historyHandler);
+
+			const beforeCallback = sinon.spy();
+			naja.addEventListener('before', beforeCallback);
+
+			naja.defaultOptions = {
+				'customOption': 42,
+			};
+
+			const request = naja.makeRequest('GET', '/makeRequest/options/defaultOptions', null, {'customOption': 24, 'anotherOption': 42});
+			assert.equal(1, this.requests.length);
+
+			request.then(() => {
+				assert.isTrue(beforeCallback.called);
+				assert.isTrue(beforeCallback.calledWith(sinon.match.object
+					.and(sinon.match.has('options', sinon.match.object
+						.and(sinon.match.has('dataType', 'post'))
+						.and(sinon.match.has('responseType', 'auto'))
+						.and(sinon.match.has('customOption', 24))
+						.and(sinon.match.has('anotherOption', 42))
+					))
+				));
+
+				done();
+			});
+
+			this.requests.pop().respond(200, {'Content-Type': 'application/json'}, JSON.stringify({answer: 42}));
+		});
+	});
 });

--- a/tests/Naja.makeRequest.js
+++ b/tests/Naja.makeRequest.js
@@ -54,6 +54,7 @@ describe('makeRequest()', function () {
 			assert.isTrue(successCallback.calledWith(sinon.match.object
 				.and(sinon.match.has('response'))
 				.and(sinon.match.has('xhr', sinon.match.instanceOf(window.XMLHttpRequest)))
+				.and(sinon.match.has('options', sinon.match.object))
 			));
 
 			assert.isTrue(completeCallback.called);
@@ -62,6 +63,7 @@ describe('makeRequest()', function () {
 				.and(sinon.match.has('error', null))
 				.and(sinon.match.has('response'))
 				.and(sinon.match.has('xhr', sinon.match.instanceOf(window.XMLHttpRequest)))
+				.and(sinon.match.has('options', sinon.match.object))
 			));
 
 			assert.isTrue(loadCallback.called);
@@ -131,6 +133,7 @@ describe('makeRequest()', function () {
 				.and(sinon.match.has('error', sinon.match.truthy))
 				.and(sinon.match.has('response'))
 				.and(sinon.match.has('xhr', sinon.match.instanceOf(window.XMLHttpRequest)))
+				.and(sinon.match.has('options', sinon.match.object))
 			));
 
 			assert.isTrue(completeCallback.called);
@@ -139,6 +142,7 @@ describe('makeRequest()', function () {
 				.and(sinon.match.has('error', sinon.match.truthy))
 				.and(sinon.match.has('response'))
 				.and(sinon.match.has('xhr', sinon.match.instanceOf(window.XMLHttpRequest)))
+				.and(sinon.match.has('options', sinon.match.object))
 			));
 
 			assert.isTrue(loadCallback.called);
@@ -191,6 +195,7 @@ describe('makeRequest()', function () {
 			.and(sinon.match.has('error', sinon.match.instanceOf(Error)))
 			.and(sinon.match.has('response', null))
 			.and(sinon.match.has('xhr', sinon.match.instanceOf(window.XMLHttpRequest)))
+			.and(sinon.match.has('options', sinon.match.object))
 		));
 	});
 


### PR DESCRIPTION
- Options are now passed to `success`, `error`, and `complete` event handlers.
- Default options can be provided via `naja.defaultOptions`.
- RedirectHandler reads the `forceRedirect` flag from `options` in addition to the response payload.