### PR TITLE
Refactor UIHandler and FormsHandler to only rebind updated snippets

### DIFF
--- a/docs/ui-binding.md
+++ b/docs/ui-binding.md
@@ -48,3 +48,18 @@ origin rules still apply, and the `interaction` event (see [Writing extensions](
 with `originalEvent` set to undefined.
 
 ?> The manual dispatch methods are available since version 1.4.0.
+
+
+## Manual bind
+
+You can also manually bind the AJAX handler to DOM nodes that are created dynamically via a different mechanism than
+Nette snippets:
+
+```js
+naja.uiHandler.bindUI(element);
+```
+
+The method searches the given `element` and its children for elements that match the configured selector and attaches
+the AJAX handler to them.
+
+?> The manual bind method is available since version 1.6.0.

--- a/src/core/FormsHandler.js
+++ b/src/core/FormsHandler.js
@@ -2,14 +2,27 @@ export default class FormsHandler {
 	netteForms;
 
 	constructor(naja) {
-		naja.addEventListener('load', this.initForms.bind(this));
+		this.naja = naja;
+
+		naja.addEventListener('init', this.initialize.bind(this));
 		naja.addEventListener('interaction', this.processForm.bind(this));
 	}
 
-	initForms() {
+	initialize() {
+		this.initForms(window.document.body);
+		this.naja.snippetHandler.addEventListener('afterUpdate', ({snippet}) => {
+			this.initForms(snippet);
+		});
+	}
+
+	initForms(element) {
 		const netteForms = this.netteForms || window.Nette;
 		if (netteForms) {
-			const forms = window.document.querySelectorAll('form');
+			if (element.tagName === 'form') {
+				netteForms.initForm(element);
+			}
+
+			const forms = element.querySelectorAll('form');
 			for (let i = 0; i < forms.length; i++) {
 				netteForms.initForm(forms.item(i));
 			}

--- a/tests/setup/mockNaja.js
+++ b/tests/setup/mockNaja.js
@@ -12,8 +12,8 @@ class SnippetHandlerMock {
 }
 
 class FormsHandlerMock {
-	static initForms() {}
-	static processForm(evt) {}
+	initForms() {}
+	processForm(evt) {}
 }
 
 class HistoryHandlerMock {


### PR DESCRIPTION
This could be a little big optimisation which revealed itself after a PM discussion with @brosland. It also opens the UIHandler's API so that one can attach Naja's listeners to DOM nodes that are created dynamically via a different mechanism than Nette snippets.

The tests need to be fixed, and this should definitely be tested in the wild as well, but for now I'd just like to find out if it's feasible, if it breaks anything, and if it makes any difference in terms of performance.