### PR TITLE
Podpora pro přenášení options z xhr.response

### DIFF
--- a/src/core/RedirectHandler.js
+++ b/src/core/RedirectHandler.js
@@ -5,7 +5,7 @@ export default class RedirectHandler {
 		naja.addEventListener('success', (evt) => {
 			const {response, options} = evt;
 			if (response.redirect) {
-				this.makeRedirect(response.redirect, response.forceRedirect || options.forceRedirect);
+				this.makeRedirect(response.redirect, response.forceRedirect || options.forceRedirect, response.options || {});
 				evt.stopImmediatePropagation();
 			}
 		});
@@ -15,7 +15,7 @@ export default class RedirectHandler {
 		};
 	}
 
-	makeRedirect(url, force) {
+	makeRedirect(url, force, options) {
 		// window.location.origin is not supported in IE 10
 		const origin = `${window.location.protocol}//${window.location.hostname}${window.location.port ? `:${window.location.port}` : ''}`;
 		const externalRedirect = /^https?/i.test(url) && ! new RegExp(`^${origin}`, 'i').test(url);
@@ -23,7 +23,7 @@ export default class RedirectHandler {
 			this.locationAdapter.assign(url);
 
 		} else {
-			this.naja.makeRequest('GET', url);
+			this.naja.makeRequest('GET', url, null, options);
 		}
 	}
 }


### PR DESCRIPTION
Ahoj,
mám takový problém, kdy chci některé formuláře po odeslání aby nezměnili URL,

`<form data-naja-history="off">` ani `<input type="submit" data-naja-history="off">` nereagují v případě kdy formulář vrátí redirect. Napadlo mě, že bych mohl v response uvést `options: {history: false}` podobně jako je response `forceRedirect: true`. Což by následný request (na stejném originu) šlo lépe ovládat.

Pak by to potřebovalo v `RedirectHandler` úpravu viz pull request. Co si o tom myslíš?