### PR TITLE
Add babel typescript preset

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -4,6 +4,7 @@ module.exports = (api) => {
 	return {
 		presets: [
 			'@babel/preset-env',
+			'@babel/preset-typescript'
 		],
 		plugins: [
 			'@babel/plugin-transform-runtime',


### PR DESCRIPTION
**Changes**

This PR adds `@babel/preset-typescript` as recommended by [Babel docs](https://babeljs.io/docs/en/babel-preset-typescript).

**Fixes**

Optional arguments in `UIHandler.clickElement` and `UIHandler.submitForm`.

Both of these functions have `options` argument that defaults to `{}`. Resulting declaration in `UIHandler.d.ts` still enforces `options` argument to be passed explicitly, thus forcing developers with TS codebase to write `naja.uiHandler.clickElement(element, {})` even though they don't want to pass any custom options.

The added babel preset ensures the compiled declaration matches all typings in source code.

