### PR TITLE
UIHandler: return the underlying makeRequest() promise from manual dispatch methods

### DIFF
--- a/docs/ui-binding.md
+++ b/docs/ui-binding.md
@@ -51,6 +51,8 @@ naja.uiHandler.submitForm(form);
 Neither `element` nor `form` have to be bound to Naja via the configured selector. However, the aforementioned allowed
 origin rules still apply, and the `interaction` event is triggered with `originalEvent` set to undefined.
 
+Since Naja 2.1.0, these methods return the promise from the underlying call to `naja.makeRequest()`.
+
 
 ## Manual bind
 

--- a/tests/Naja.UIHandler.js
+++ b/tests/Naja.UIHandler.js
@@ -430,17 +430,22 @@ describe('UIHandler', function () {
 			const naja = mockNaja();
 			const mock = sinon.mock(naja);
 
+			const expectedResult = {answer: 42};
+
 			mock.expects('makeRequest')
 				.withExactArgs('GET', 'http://localhost:9876/UIHandler/clickElement', null, {})
-				.once();
+				.once()
+				.returns(Promise.resolve(expectedResult));
 
 			const a = document.createElement('a');
 			a.href = '/UIHandler/clickElement';
 
 			const handler = new UIHandler(naja);
-			handler.clickElement(a);
-
-			mock.verify();
+			return handler.clickElement(a)
+				.then((result) => {
+					assert.deepEqual(result, expectedResult);
+					mock.verify();
+				});
 		});
 
 		it('triggers interaction event', function () {
@@ -477,18 +482,23 @@ describe('UIHandler', function () {
 			const naja = mockNaja();
 			const mock = sinon.mock(naja);
 
+			const expectedResult = {answer: 42};
+
 			mock.expects('makeRequest')
 				.withExactArgs('POST', '/UIHandler/submitForm', sinon.match.instanceOf(FormData), {})
-				.once();
+				.once()
+				.returns(Promise.resolve(expectedResult));
 
 			const form = document.createElement('form');
 			form.method = 'POST';
 			form.action = '/UIHandler/submitForm';
 
 			const handler = new UIHandler(naja);
-			handler.submitForm(form);
-
-			mock.verify();
+			return handler.submitForm(form)
+				.then((result) => {
+					assert.deepEqual(result, expectedResult);
+					mock.verify();
+				});
 		});
 
 		it('triggers interaction event', function () {


### PR DESCRIPTION
Closes #176 