### PR TITLE
core: serialize simple POJO data into query string for GET and HEAD requests

### DIFF
--- a/src/Naja.ts
+++ b/src/Naja.ts
@@ -94,9 +94,11 @@ export class Naja extends EventTarget {
 			},
 		};
 
-		if (method.toUpperCase() === 'GET' && data instanceof FormData) {
+		const isDataPojo = data !== null && Object.getPrototypeOf(data) === Object.prototype;
+		if (['GET', 'HEAD'].includes(method.toUpperCase()) && (data instanceof FormData || isDataPojo)) {
 			const urlObject = new URL(url, location.href);
-			for (const [key, value] of data) {
+			const iterableData = isDataPojo ? Object.entries(data) : data;
+			for (const [key, value] of iterableData) {
 				urlObject.searchParams.append(key, String(value));
 			}
 
@@ -110,7 +112,7 @@ export class Naja extends EventTarget {
 			...options.fetch,
 			method,
 			headers: new Headers(options.fetch!.headers || {}),
-			body: data !== null && Object.getPrototypeOf(data) === Object.prototype
+			body: data !== null && isDataPojo
 				? new URLSearchParams(data)
 				: data,
 			signal: abortController.signal,

--- a/tests/Naja.makeRequest.js
+++ b/tests/Naja.makeRequest.js
@@ -350,7 +350,26 @@ describe('makeRequest()', function () {
 		const request = naja.makeRequest('GET', '/makeRequest/getFormData', formData);
 		return request.then((payload) => {
 			assert.deepEqual(payload, {answer: 42});
-		})
+		});
+	});
+
+	it('should submit GET POJO in URL', function () {
+		const naja = mockNaja();
+		naja.initialize();
+		cleanPopstateListener(naja.historyHandler);
+
+		const data = {
+			foo: 'bar',
+			baz: 42,
+		};
+
+		this.fetchMock.when((request) => request.url === 'http://localhost:9876/makeRequest/getPOJO?foo=bar&baz=42')
+			.respond(200, {'Content-Type': 'application/json'}, {answer: 42});
+
+		const request = naja.makeRequest('GET', '/makeRequest/getPOJO', data);
+		return request.then((payload) => {
+			assert.deepEqual(payload, {answer: 42});
+		});
 	});
 
 	describe('options', function () {


### PR DESCRIPTION
Closes #175 